### PR TITLE
feat(chat): add video upload support for Gemini models

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@ out-*
 node_modules
 coverage/
 mock/
+changes.patch
 
 .DS_Store
 

--- a/apps/web-evals/package.json
+++ b/apps/web-evals/package.json
@@ -51,6 +51,7 @@
 		"@roo-code/config-eslint": "workspace:^",
 		"@roo-code/config-typescript": "workspace:^",
 		"@tailwindcss/postcss": "^4",
+		"@types/node": "20.x",
 		"@types/ps-tree": "^1.1.6",
 		"@types/react": "^18.3.23",
 		"@types/react-dom": "^18.3.5",

--- a/changes.patch
+++ b/changes.patch
@@ -1,0 +1,340 @@
+diff --git a/webview-ui/src/components/chat/ChatRow.tsx b/webview-ui/src/components/chat/ChatRow.tsx
+index c508f7e9..abdd9ae3 100644
+--- a/webview-ui/src/components/chat/ChatRow.tsx
++++ b/webview-ui/src/components/chat/ChatRow.tsx
+@@ -26,10 +26,10 @@ import CodeAccordian from "../common/CodeAccordian"
+ import CodeBlock from "../common/CodeBlock"
+ import MarkdownBlock from "../common/MarkdownBlock"
+ import { ReasoningBlock } from "./ReasoningBlock"
+-import Thumbnails from "../common/Thumbnails"
+ import McpResourceRow from "../mcp/McpResourceRow"
+ 
+ import { Mention } from "./Mention"
++import MediaThumbnails from "../common/MediaThumbnails"
+ import { CheckpointSaved } from "./checkpoints/CheckpointSaved"
+ import { FollowUpSuggest } from "./FollowUpSuggest"
+ import { BatchFilePermission } from "./BatchFilePermission"
+@@ -1080,7 +1080,7 @@ export const ChatRowContent = ({
+ 								</div>
+ 							)}
+ 							{!isEditing && message.images && message.images.length > 0 && (
+-								<Thumbnails images={message.images} style={{ marginTop: "8px" }} />
++								<MediaThumbnails mediaItems={message.images} style={{ marginTop: "8px" }} />
+ 							)}
+ 						</div>
+ 					)
+diff --git a/webview-ui/src/components/chat/ChatTextArea.tsx b/webview-ui/src/components/chat/ChatTextArea.tsx
+index 7b404ddc..4484bea0 100644
+--- a/webview-ui/src/components/chat/ChatTextArea.tsx
++++ b/webview-ui/src/components/chat/ChatTextArea.tsx
+@@ -21,9 +21,9 @@ import {
+ import { convertToMentionPath } from "@/utils/path-mentions"
+ import { SelectDropdown, DropdownOptionType, Button, StandardTooltip } from "@/components/ui"
+ 
+-import Thumbnails from "../common/Thumbnails"
+ import ModeSelector from "./ModeSelector"
+ import { MAX_IMAGES_PER_MESSAGE } from "./ChatView"
++import MediaThumbnails from "../common/MediaThumbnails"
+ import ContextMenu from "./ContextMenu"
+ import { VolumeX, Pin, Check, Image, WandSparkles, SendHorizontal } from "lucide-react"
+ import { IndexingStatusBadge } from "./IndexingStatusBadge"
+@@ -36,8 +36,8 @@ interface ChatTextAreaProps {
+ 	sendingDisabled: boolean
+ 	selectApiConfigDisabled: boolean
+ 	placeholderText: string
+-	selectedImages: string[]
+-	setSelectedImages: React.Dispatch<React.SetStateAction<string[]>>
++	selectedMedia: string[]
++	setSelectedMedia: React.Dispatch<React.SetStateAction<string[]>>
+ 	onSend: () => void
+ 	onSelectImages: () => void
+ 	shouldDisableImages: boolean
+@@ -45,6 +45,7 @@ interface ChatTextAreaProps {
+ 	mode: Mode
+ 	setMode: (value: Mode) => void
+ 	modeShortcutText: string
++	acceptedFileTypes: string[]
+ }
+ 
+ const ChatTextArea = forwardRef<HTMLTextAreaElement, ChatTextAreaProps>(
+@@ -55,8 +56,8 @@ const ChatTextArea = forwardRef<HTMLTextAreaElement, ChatTextAreaProps>(
+ 			sendingDisabled,
+ 			selectApiConfigDisabled,
+ 			placeholderText,
+-			selectedImages,
+-			setSelectedImages,
++			selectedMedia,
++			setSelectedMedia,
+ 			onSend,
+ 			onSelectImages,
+ 			shouldDisableImages,
+@@ -64,6 +65,7 @@ const ChatTextArea = forwardRef<HTMLTextAreaElement, ChatTextAreaProps>(
+ 			mode,
+ 			setMode,
+ 			modeShortcutText,
++			acceptedFileTypes,
+ 		},
+ 		ref,
+ 	) => {
+@@ -592,11 +594,9 @@ const ChatTextArea = forwardRef<HTMLTextAreaElement, ChatTextAreaProps>(
+ 					return
+ 				}
+ 
+-				const acceptedTypes = ["png", "jpeg", "webp"]
+-
+ 				const imageItems = Array.from(items).filter((item) => {
+ 					const [type, subtype] = item.type.split("/")
+-					return type === "image" && acceptedTypes.includes(subtype)
++					return (type === "image" || type === "video") && acceptedFileTypes.includes(subtype)
+ 				})
+ 
+ 				if (!shouldDisableImages && imageItems.length > 0) {
+@@ -631,13 +631,13 @@ const ChatTextArea = forwardRef<HTMLTextAreaElement, ChatTextAreaProps>(
+ 					const dataUrls = imageDataArray.filter((dataUrl): dataUrl is string => dataUrl !== null)
+ 
+ 					if (dataUrls.length > 0) {
+-						setSelectedImages((prevImages) => [...prevImages, ...dataUrls].slice(0, MAX_IMAGES_PER_MESSAGE))
++						setSelectedMedia((prevItems) => [...prevItems, ...dataUrls].slice(0, MAX_IMAGES_PER_MESSAGE))
+ 					} else {
+ 						console.warn(t("chat:noValidImages"))
+ 					}
+ 				}
+ 			},
+-			[shouldDisableImages, setSelectedImages, cursorPosition, setInputValue, inputValue, t],
++			[shouldDisableImages, setSelectedMedia, cursorPosition, setInputValue, inputValue, t],
+ 		)
+ 
+ 		const handleMenuMouseDown = useCallback(() => {
+@@ -726,11 +726,9 @@ const ChatTextArea = forwardRef<HTMLTextAreaElement, ChatTextAreaProps>(
+ 				const files = Array.from(e.dataTransfer.files)
+ 
+ 				if (files.length > 0) {
+-					const acceptedTypes = ["png", "jpeg", "webp"]
+-
+ 					const imageFiles = files.filter((file) => {
+ 						const [type, subtype] = file.type.split("/")
+-						return type === "image" && acceptedTypes.includes(subtype)
++						return (type === "image" || type === "video") && acceptedFileTypes.includes(subtype)
+ 					})
+ 
+ 					if (!shouldDisableImages && imageFiles.length > 0) {
+@@ -756,8 +754,8 @@ const ChatTextArea = forwardRef<HTMLTextAreaElement, ChatTextAreaProps>(
+ 						const dataUrls = imageDataArray.filter((dataUrl): dataUrl is string => dataUrl !== null)
+ 
+ 						if (dataUrls.length > 0) {
+-							setSelectedImages((prevImages) =>
+-								[...prevImages, ...dataUrls].slice(0, MAX_IMAGES_PER_MESSAGE),
++							setSelectedMedia((prevItems) =>
++								[...prevItems, ...dataUrls].slice(0, MAX_IMAGES_PER_MESSAGE),
+ 							)
+ 
+ 							if (typeof vscode !== "undefined") {
+@@ -777,7 +775,7 @@ const ChatTextArea = forwardRef<HTMLTextAreaElement, ChatTextAreaProps>(
+ 				setCursorPosition,
+ 				setIntendedCursorPosition,
+ 				shouldDisableImages,
+-				setSelectedImages,
++				setSelectedMedia,
+ 				t,
+ 			],
+ 		)
+@@ -1031,10 +1029,10 @@ const ChatTextArea = forwardRef<HTMLTextAreaElement, ChatTextAreaProps>(
+ 					</div>
+ 				</div>
+ 
+-				{selectedImages.length > 0 && (
+-					<Thumbnails
+-						images={selectedImages}
+-						setImages={setSelectedImages}
++				{selectedMedia.length > 0 && (
++					<MediaThumbnails
++						mediaItems={selectedMedia}
++						setMediaItems={setSelectedMedia}
+ 						style={{
+ 							left: "16px",
+ 							zIndex: 2,
+diff --git a/webview-ui/src/components/chat/ChatView.tsx b/webview-ui/src/components/chat/ChatView.tsx
+index 0f0b056f..d5b5b66a 100644
+--- a/webview-ui/src/components/chat/ChatView.tsx
++++ b/webview-ui/src/components/chat/ChatView.tsx
+@@ -150,7 +150,7 @@ const ChatViewComponent: React.ForwardRefRenderFunction<ChatViewRef, ChatViewPro
+ 	const [inputValue, setInputValue] = useState("")
+ 	const textAreaRef = useRef<HTMLTextAreaElement>(null)
+ 	const [sendingDisabled, setSendingDisabled] = useState(false)
+-	const [selectedImages, setSelectedImages] = useState<string[]>([])
++	const [selectedMedia, setSelectedMedia] = useState<string[]>([])
+ 
+ 	// we need to hold on to the ask because useEffect > lastMessage will always let us know when an ask comes in and handle it, but by the time handleMessage is called, the last message might not be the ask anymore (it could be a say that followed)
+ 	const [clineAsk, setClineAsk] = useState<ClineAsk | undefined>(undefined)
+@@ -393,7 +393,7 @@ const ChatViewComponent: React.ForwardRefRenderFunction<ChatViewRef, ChatViewPro
+ 						case "api_req_started":
+ 							if (secondLastMessage?.ask === "command_output") {
+ 								setSendingDisabled(true)
+-								setSelectedImages([])
++								setSelectedMedia([])
+ 								setClineAsk(undefined)
+ 								setEnableButtons(false)
+ 							}
+@@ -526,7 +526,7 @@ const ChatViewComponent: React.ForwardRefRenderFunction<ChatViewRef, ChatViewPro
+ 		// Only reset message-specific state, preserving mode.
+ 		setInputValue("")
+ 		setSendingDisabled(true)
+-		setSelectedImages([])
++		setSelectedMedia([])
+ 		setClineAsk(undefined)
+ 		setEnableButtons(false)
+ 		// Do not reset mode here as it should persist.
+@@ -586,9 +586,9 @@ const ChatViewComponent: React.ForwardRefRenderFunction<ChatViewRef, ChatViewPro
+ 			}
+ 
+ 			setInputValue(newValue)
+-			setSelectedImages([...selectedImages, ...images])
++			setSelectedMedia([...selectedMedia, ...images])
+ 		},
+-		[inputValue, selectedImages],
++		[inputValue, selectedMedia],
+ 	)
+ 
+ 	const startNewTask = useCallback(() => vscode.postMessage({ type: "clearTask" }), [])
+@@ -624,7 +624,7 @@ const ChatViewComponent: React.ForwardRefRenderFunction<ChatViewRef, ChatViewPro
+ 					}
+ 					// Clear input state after sending
+ 					setInputValue("")
+-					setSelectedImages([])
++					setSelectedMedia([])
+ 					break
+ 				case "completion_result":
+ 				case "resume_completed_task":
+@@ -680,7 +680,7 @@ const ChatViewComponent: React.ForwardRefRenderFunction<ChatViewRef, ChatViewPro
+ 					}
+ 					// Clear input state after sending
+ 					setInputValue("")
+-					setSelectedImages([])
++					setSelectedMedia([])
+ 					break
+ 				case "command_output":
+ 					vscode.postMessage({ type: "terminalOperation", terminalOperation: "abort" })
+@@ -699,8 +699,22 @@ const ChatViewComponent: React.ForwardRefRenderFunction<ChatViewRef, ChatViewPro
+ 
+ 	const selectImages = useCallback(() => vscode.postMessage({ type: "selectImages" }), [])
+ 
++	const acceptedFileTypes = useMemo(() => {
++		const modelId = apiConfiguration?.apiModelId
++		const isGeminiPro = modelId?.includes("gemini-2.5-pro")
++		const isGeminiFlash = modelId?.includes("gemini-1.5-flash")
++
++		if ((isGeminiPro || isGeminiFlash) && model?.supportsImages) {
++			return ["png", "jpeg", "webp", "heic", "heif", "mp4", "mov", "avi", "wmv", "flv", "webm"]
++		}
++		if (model?.supportsImages) {
++			return ["png", "jpeg", "webp", "heic", "heif"]
++		}
++		return []
++	}, [apiConfiguration, model])
++
+ 	const shouldDisableImages =
+-		!model?.supportsImages || sendingDisabled || selectedImages.length >= MAX_IMAGES_PER_MESSAGE
++		!model?.supportsImages || sendingDisabled || selectedMedia.length >= MAX_IMAGES_PER_MESSAGE
+ 
+ 	const handleMessage = useCallback(
+ 		(e: MessageEvent) => {
+@@ -722,8 +736,8 @@ const ChatViewComponent: React.ForwardRefRenderFunction<ChatViewRef, ChatViewPro
+ 				case "selectedImages":
+ 					const newImages = message.images ?? []
+ 					if (newImages.length > 0) {
+-						setSelectedImages((prevImages) =>
+-							[...prevImages, ...newImages].slice(0, MAX_IMAGES_PER_MESSAGE),
++						setSelectedMedia((prevItems) =>
++							[...prevItems, ...newImages].slice(0, MAX_IMAGES_PER_MESSAGE),
+ 						)
+ 					}
+ 					break
+@@ -1595,9 +1609,9 @@ const ChatViewComponent: React.ForwardRefRenderFunction<ChatViewRef, ChatViewPro
+ 	useImperativeHandle(ref, () => ({
+ 		acceptInput: () => {
+ 			if (enableButtons && primaryButtonText) {
+-				handlePrimaryButtonClick(inputValue, selectedImages)
+-			} else if (!sendingDisabled && !isProfileDisabled && (inputValue.trim() || selectedImages.length > 0)) {
+-				handleSendMessage(inputValue, selectedImages)
++				handlePrimaryButtonClick(inputValue, selectedMedia)
++			} else if (!sendingDisabled && !isProfileDisabled && (inputValue.trim() || selectedMedia.length > 0)) {
++				handleSendMessage(inputValue, selectedMedia)
+ 			}
+ 		},
+ 	}))
+@@ -1797,7 +1811,7 @@ const ChatViewComponent: React.ForwardRefRenderFunction<ChatViewRef, ChatViewPro
+ 												appearance="primary"
+ 												disabled={!enableButtons}
+ 												className={secondaryButtonText ? "flex-1 mr-[6px]" : "flex-[2] mr-0"}
+-												onClick={() => handlePrimaryButtonClick(inputValue, selectedImages)}>
++												onClick={() => handlePrimaryButtonClick(inputValue, selectedMedia)}>
+ 												{primaryButtonText}
+ 											</VSCodeButton>
+ 										</StandardTooltip>
+@@ -1819,7 +1833,7 @@ const ChatViewComponent: React.ForwardRefRenderFunction<ChatViewRef, ChatViewPro
+ 												appearance="secondary"
+ 												disabled={!enableButtons && !(isStreaming && !didClickCancel)}
+ 												className={isStreaming ? "flex-[2] ml-0" : "flex-1 ml-[6px]"}
+-												onClick={() => handleSecondaryButtonClick(inputValue, selectedImages)}>
++												onClick={() => handleSecondaryButtonClick(inputValue, selectedMedia)}>
+ 												{isStreaming ? t("chat:cancel.title") : secondaryButtonText}
+ 											</VSCodeButton>
+ 										</StandardTooltip>
+@@ -1838,11 +1852,12 @@ const ChatViewComponent: React.ForwardRefRenderFunction<ChatViewRef, ChatViewPro
+ 				sendingDisabled={sendingDisabled || isProfileDisabled}
+ 				selectApiConfigDisabled={sendingDisabled && clineAsk !== "api_req_failed"}
+ 				placeholderText={placeholderText}
+-				selectedImages={selectedImages}
+-				setSelectedImages={setSelectedImages}
+-				onSend={() => handleSendMessage(inputValue, selectedImages)}
++				selectedMedia={selectedMedia}
++				setSelectedMedia={setSelectedMedia}
++				onSend={() => handleSendMessage(inputValue, selectedMedia)}
+ 				onSelectImages={selectImages}
+ 				shouldDisableImages={shouldDisableImages}
++				acceptedFileTypes={acceptedFileTypes}
+ 				onHeightChange={() => {
+ 					if (isAtBottom) {
+ 						scrollToBottomAuto()
+diff --git a/webview-ui/src/components/chat/TaskHeader.tsx b/webview-ui/src/components/chat/TaskHeader.tsx
+index 1896df48..dd3bd1fb 100644
+--- a/webview-ui/src/components/chat/TaskHeader.tsx
++++ b/webview-ui/src/components/chat/TaskHeader.tsx
+@@ -14,7 +14,7 @@ import { Button, StandardTooltip } from "@src/components/ui"
+ import { useExtensionState } from "@src/context/ExtensionStateContext"
+ import { useSelectedModel } from "@/components/ui/hooks/useSelectedModel"
+ 
+-import Thumbnails from "../common/Thumbnails"
++import MediaThumbnails from "../common/MediaThumbnails"
+ 
+ import { TaskActions } from "./TaskActions"
+ import { ShareButton } from "./ShareButton"
+@@ -142,7 +142,7 @@ const TaskHeader = ({
+ 								<Mention text={task.text} />
+ 							</div>
+ 						</div>
+-						{task.images && task.images.length > 0 && <Thumbnails images={task.images} />}
++						{task.images && task.images.length > 0 && <MediaThumbnails mediaItems={task.images} />}
+ 
+ 						<div className="flex flex-col gap-1">
+ 							{isTaskExpanded && contextWindow > 0 && (
+diff --git a/webview-ui/src/components/chat/__tests__/ChatTextArea.spec.tsx b/webview-ui/src/components/chat/__tests__/ChatTextArea.spec.tsx
+index 97342020..be7a56cb 100644
+--- a/webview-ui/src/components/chat/__tests__/ChatTextArea.spec.tsx
++++ b/webview-ui/src/components/chat/__tests__/ChatTextArea.spec.tsx
+@@ -54,12 +54,13 @@ describe("ChatTextArea", () => {
+ 		onSelectImages: vi.fn(),
+ 		shouldDisableImages: false,
+ 		placeholderText: "Type a message...",
+-		selectedImages: [],
+-		setSelectedImages: vi.fn(),
++		selectedMedia: [],
++		setSelectedMedia: vi.fn(),
+ 		onHeightChange: vi.fn(),
+ 		mode: defaultModeSlug,
+ 		setMode: vi.fn(),
+ 		modeShortcutText: "(⌘. for next mode)",
++		acceptedFileTypes: [],
+ 	}
+ 
+ 	beforeEach(() => {

--- a/package.json
+++ b/package.json
@@ -53,6 +53,16 @@
 			"esbuild": ">=0.25.0",
 			"undici": ">=5.29.0",
 			"brace-expansion": ">=2.0.2"
-		}
+		},
+		"onlyBuiltDependencies": [
+			"@tailwindcss/oxide",
+			"@vscode/vsce-sign",
+			"better-sqlite3",
+			"core-js",
+			"esbuild",
+			"keytar",
+			"puppeteer-chromium-resolver",
+			"sharp"
+		]
 	}
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -219,6 +219,9 @@ importers:
       '@tailwindcss/postcss':
         specifier: ^4
         version: 4.1.8
+      '@types/node':
+        specifier: 20.x
+        version: 20.19.1
       '@types/ps-tree':
         specifier: ^1.1.6
         version: 1.1.6
@@ -233,7 +236,7 @@ importers:
         version: 4.1.6
       vitest:
         specifier: ^3.2.3
-        version: 3.2.4(@types/debug@4.1.12)(@types/node@22.15.29)(@vitest/ui@3.2.4)(jiti@2.4.2)(jsdom@26.1.0)(lightningcss@1.30.1)(tsx@4.19.4)(yaml@2.8.0)
+        version: 3.2.4(@types/debug@4.1.12)(@types/node@20.19.1)(@vitest/ui@3.2.4)(jiti@2.4.2)(jsdom@26.1.0)(lightningcss@1.30.1)(tsx@4.19.4)(yaml@2.8.0)
 
   apps/web-roo-code:
     dependencies:
@@ -11004,7 +11007,7 @@ snapshots:
       '@jest/schemas': 29.6.3
       '@types/istanbul-lib-coverage': 2.0.6
       '@types/istanbul-reports': 3.0.4
-      '@types/node': 20.17.57
+      '@types/node': 20.19.1
       '@types/yargs': 17.0.33
       chalk: 4.1.2
 
@@ -12983,7 +12986,7 @@ snapshots:
   '@types/glob@8.1.0':
     dependencies:
       '@types/minimatch': 5.1.2
-      '@types/node': 20.17.57
+      '@types/node': 20.19.1
 
   '@types/hast@3.0.4':
     dependencies:
@@ -13036,12 +13039,12 @@ snapshots:
 
   '@types/node-fetch@2.6.12':
     dependencies:
-      '@types/node': 20.17.57
+      '@types/node': 20.19.1
       form-data: 4.0.2
 
   '@types/node-ipc@9.2.3':
     dependencies:
-      '@types/node': 20.17.57
+      '@types/node': 20.19.1
 
   '@types/node@12.20.55': {}
 
@@ -13133,7 +13136,7 @@ snapshots:
 
   '@types/yauzl@2.10.3':
     dependencies:
-      '@types/node': 20.17.57
+      '@types/node': 20.19.1
     optional: true
 
   '@typescript-eslint/eslint-plugin@8.32.1(@typescript-eslint/parser@8.32.1(eslint@9.27.0(jiti@2.4.2))(typescript@5.8.3))(eslint@9.27.0(jiti@2.4.2))(typescript@5.8.3)':
@@ -13258,13 +13261,13 @@ snapshots:
     optionalDependencies:
       vite: 6.3.5(@types/node@20.17.57)(jiti@2.4.2)(lightningcss@1.30.1)(tsx@4.19.4)(yaml@2.8.0)
 
-  '@vitest/mocker@3.2.4(vite@6.3.5(@types/node@22.15.29)(jiti@2.4.2)(lightningcss@1.30.1)(tsx@4.19.4)(yaml@2.8.0))':
+  '@vitest/mocker@3.2.4(vite@6.3.5(@types/node@20.19.1)(jiti@2.4.2)(lightningcss@1.30.1)(tsx@4.19.4)(yaml@2.8.0))':
     dependencies:
       '@vitest/spy': 3.2.4
       estree-walker: 3.0.3
       magic-string: 0.30.17
     optionalDependencies:
-      vite: 6.3.5(@types/node@22.15.29)(jiti@2.4.2)(lightningcss@1.30.1)(tsx@4.19.4)(yaml@2.8.0)
+      vite: 6.3.5(@types/node@20.19.1)(jiti@2.4.2)(lightningcss@1.30.1)(tsx@4.19.4)(yaml@2.8.0)
 
   '@vitest/pretty-format@3.2.4':
     dependencies:
@@ -13295,7 +13298,7 @@ snapshots:
       sirv: 3.0.1
       tinyglobby: 0.2.14
       tinyrainbow: 2.0.0
-      vitest: 3.2.4(@types/debug@4.1.12)(@types/node@22.15.29)(@vitest/ui@3.2.4)(jiti@2.4.2)(jsdom@26.1.0)(lightningcss@1.30.1)(tsx@4.19.4)(yaml@2.8.0)
+      vitest: 3.2.4(@types/debug@4.1.12)(@types/node@20.19.1)(@vitest/ui@3.2.4)(jiti@2.4.2)(jsdom@26.1.0)(lightningcss@1.30.1)(tsx@4.19.4)(yaml@2.8.0)
 
   '@vitest/utils@3.2.4':
     dependencies:
@@ -16095,7 +16098,7 @@ snapshots:
   jest-util@29.7.0:
     dependencies:
       '@jest/types': 29.6.3
-      '@types/node': 20.17.57
+      '@types/node': 20.19.1
       chalk: 4.1.2
       ci-info: 3.9.0
       graceful-fs: 4.2.11
@@ -19540,13 +19543,13 @@ snapshots:
       - tsx
       - yaml
 
-  vite-node@3.2.4(@types/node@22.15.29)(jiti@2.4.2)(lightningcss@1.30.1)(tsx@4.19.4)(yaml@2.8.0):
+  vite-node@3.2.4(@types/node@20.19.1)(jiti@2.4.2)(lightningcss@1.30.1)(tsx@4.19.4)(yaml@2.8.0):
     dependencies:
       cac: 6.7.14
       debug: 4.4.1(supports-color@8.1.1)
       es-module-lexer: 1.7.0
       pathe: 2.0.3
-      vite: 6.3.5(@types/node@22.15.29)(jiti@2.4.2)(lightningcss@1.30.1)(tsx@4.19.4)(yaml@2.8.0)
+      vite: 6.3.5(@types/node@20.19.1)(jiti@2.4.2)(lightningcss@1.30.1)(tsx@4.19.4)(yaml@2.8.0)
     transitivePeerDependencies:
       - '@types/node'
       - jiti
@@ -19593,7 +19596,7 @@ snapshots:
       tsx: 4.19.4
       yaml: 2.8.0
 
-  vite@6.3.5(@types/node@22.15.29)(jiti@2.4.2)(lightningcss@1.30.1)(tsx@4.19.4)(yaml@2.8.0):
+  vite@6.3.5(@types/node@20.19.1)(jiti@2.4.2)(lightningcss@1.30.1)(tsx@4.19.4)(yaml@2.8.0):
     dependencies:
       esbuild: 0.25.5
       fdir: 6.4.4(picomatch@4.0.2)
@@ -19602,7 +19605,7 @@ snapshots:
       rollup: 4.40.2
       tinyglobby: 0.2.13
     optionalDependencies:
-      '@types/node': 22.15.29
+      '@types/node': 20.19.1
       fsevents: 2.3.3
       jiti: 2.4.2
       lightningcss: 1.30.1
@@ -19697,11 +19700,11 @@ snapshots:
       - tsx
       - yaml
 
-  vitest@3.2.4(@types/debug@4.1.12)(@types/node@22.15.29)(@vitest/ui@3.2.4)(jiti@2.4.2)(jsdom@26.1.0)(lightningcss@1.30.1)(tsx@4.19.4)(yaml@2.8.0):
+  vitest@3.2.4(@types/debug@4.1.12)(@types/node@20.19.1)(@vitest/ui@3.2.4)(jiti@2.4.2)(jsdom@26.1.0)(lightningcss@1.30.1)(tsx@4.19.4)(yaml@2.8.0):
     dependencies:
       '@types/chai': 5.2.2
       '@vitest/expect': 3.2.4
-      '@vitest/mocker': 3.2.4(vite@6.3.5(@types/node@22.15.29)(jiti@2.4.2)(lightningcss@1.30.1)(tsx@4.19.4)(yaml@2.8.0))
+      '@vitest/mocker': 3.2.4(vite@6.3.5(@types/node@20.19.1)(jiti@2.4.2)(lightningcss@1.30.1)(tsx@4.19.4)(yaml@2.8.0))
       '@vitest/pretty-format': 3.2.4
       '@vitest/runner': 3.2.4
       '@vitest/snapshot': 3.2.4
@@ -19719,12 +19722,12 @@ snapshots:
       tinyglobby: 0.2.14
       tinypool: 1.1.1
       tinyrainbow: 2.0.0
-      vite: 6.3.5(@types/node@22.15.29)(jiti@2.4.2)(lightningcss@1.30.1)(tsx@4.19.4)(yaml@2.8.0)
-      vite-node: 3.2.4(@types/node@22.15.29)(jiti@2.4.2)(lightningcss@1.30.1)(tsx@4.19.4)(yaml@2.8.0)
+      vite: 6.3.5(@types/node@20.19.1)(jiti@2.4.2)(lightningcss@1.30.1)(tsx@4.19.4)(yaml@2.8.0)
+      vite-node: 3.2.4(@types/node@20.19.1)(jiti@2.4.2)(lightningcss@1.30.1)(tsx@4.19.4)(yaml@2.8.0)
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@types/debug': 4.1.12
-      '@types/node': 22.15.29
+      '@types/node': 20.19.1
       '@vitest/ui': 3.2.4(vitest@3.2.4)
       jsdom: 26.1.0
     transitivePeerDependencies:

--- a/webview-ui/src/components/chat/ChatRow.tsx
+++ b/webview-ui/src/components/chat/ChatRow.tsx
@@ -26,10 +26,10 @@ import CodeAccordian from "../common/CodeAccordian"
 import CodeBlock from "../common/CodeBlock"
 import MarkdownBlock from "../common/MarkdownBlock"
 import { ReasoningBlock } from "./ReasoningBlock"
-import Thumbnails from "../common/Thumbnails"
 import McpResourceRow from "../mcp/McpResourceRow"
 
 import { Mention } from "./Mention"
+import MediaThumbnails from "../common/MediaThumbnails"
 import { CheckpointSaved } from "./checkpoints/CheckpointSaved"
 import { FollowUpSuggest } from "./FollowUpSuggest"
 import { BatchFilePermission } from "./BatchFilePermission"
@@ -1080,7 +1080,7 @@ export const ChatRowContent = ({
 								</div>
 							)}
 							{!isEditing && message.images && message.images.length > 0 && (
-								<Thumbnails images={message.images} style={{ marginTop: "8px" }} />
+								<MediaThumbnails mediaItems={message.images} style={{ marginTop: "8px" }} />
 							)}
 						</div>
 					)

--- a/webview-ui/src/components/chat/ChatTextArea.tsx
+++ b/webview-ui/src/components/chat/ChatTextArea.tsx
@@ -21,9 +21,9 @@ import {
 import { convertToMentionPath } from "@/utils/path-mentions"
 import { SelectDropdown, DropdownOptionType, Button, StandardTooltip } from "@/components/ui"
 
-import Thumbnails from "../common/Thumbnails"
 import ModeSelector from "./ModeSelector"
 import { MAX_IMAGES_PER_MESSAGE } from "./ChatView"
+import MediaThumbnails from "../common/MediaThumbnails"
 import ContextMenu from "./ContextMenu"
 import { VolumeX, Pin, Check, Image, WandSparkles, SendHorizontal } from "lucide-react"
 import { IndexingStatusBadge } from "./IndexingStatusBadge"
@@ -36,8 +36,8 @@ interface ChatTextAreaProps {
 	sendingDisabled: boolean
 	selectApiConfigDisabled: boolean
 	placeholderText: string
-	selectedImages: string[]
-	setSelectedImages: React.Dispatch<React.SetStateAction<string[]>>
+	selectedMedia: string[]
+	setSelectedMedia: React.Dispatch<React.SetStateAction<string[]>>
 	onSend: () => void
 	onSelectImages: () => void
 	shouldDisableImages: boolean
@@ -45,6 +45,7 @@ interface ChatTextAreaProps {
 	mode: Mode
 	setMode: (value: Mode) => void
 	modeShortcutText: string
+	acceptedFileTypes: string[]
 }
 
 const ChatTextArea = forwardRef<HTMLTextAreaElement, ChatTextAreaProps>(
@@ -55,8 +56,8 @@ const ChatTextArea = forwardRef<HTMLTextAreaElement, ChatTextAreaProps>(
 			sendingDisabled,
 			selectApiConfigDisabled,
 			placeholderText,
-			selectedImages,
-			setSelectedImages,
+			selectedMedia,
+			setSelectedMedia,
 			onSend,
 			onSelectImages,
 			shouldDisableImages,
@@ -64,6 +65,7 @@ const ChatTextArea = forwardRef<HTMLTextAreaElement, ChatTextAreaProps>(
 			mode,
 			setMode,
 			modeShortcutText,
+			acceptedFileTypes,
 		},
 		ref,
 	) => {
@@ -592,11 +594,9 @@ const ChatTextArea = forwardRef<HTMLTextAreaElement, ChatTextAreaProps>(
 					return
 				}
 
-				const acceptedTypes = ["png", "jpeg", "webp"]
-
 				const imageItems = Array.from(items).filter((item) => {
 					const [type, subtype] = item.type.split("/")
-					return type === "image" && acceptedTypes.includes(subtype)
+					return (type === "image" || type === "video") && acceptedFileTypes.includes(subtype)
 				})
 
 				if (!shouldDisableImages && imageItems.length > 0) {
@@ -631,13 +631,13 @@ const ChatTextArea = forwardRef<HTMLTextAreaElement, ChatTextAreaProps>(
 					const dataUrls = imageDataArray.filter((dataUrl): dataUrl is string => dataUrl !== null)
 
 					if (dataUrls.length > 0) {
-						setSelectedImages((prevImages) => [...prevImages, ...dataUrls].slice(0, MAX_IMAGES_PER_MESSAGE))
+						setSelectedMedia((prevItems) => [...prevItems, ...dataUrls].slice(0, MAX_IMAGES_PER_MESSAGE))
 					} else {
 						console.warn(t("chat:noValidImages"))
 					}
 				}
 			},
-			[shouldDisableImages, setSelectedImages, cursorPosition, setInputValue, inputValue, t],
+			[shouldDisableImages, setSelectedMedia, cursorPosition, setInputValue, inputValue, t],
 		)
 
 		const handleMenuMouseDown = useCallback(() => {
@@ -726,11 +726,9 @@ const ChatTextArea = forwardRef<HTMLTextAreaElement, ChatTextAreaProps>(
 				const files = Array.from(e.dataTransfer.files)
 
 				if (files.length > 0) {
-					const acceptedTypes = ["png", "jpeg", "webp"]
-
 					const imageFiles = files.filter((file) => {
 						const [type, subtype] = file.type.split("/")
-						return type === "image" && acceptedTypes.includes(subtype)
+						return (type === "image" || type === "video") && acceptedFileTypes.includes(subtype)
 					})
 
 					if (!shouldDisableImages && imageFiles.length > 0) {
@@ -756,8 +754,8 @@ const ChatTextArea = forwardRef<HTMLTextAreaElement, ChatTextAreaProps>(
 						const dataUrls = imageDataArray.filter((dataUrl): dataUrl is string => dataUrl !== null)
 
 						if (dataUrls.length > 0) {
-							setSelectedImages((prevImages) =>
-								[...prevImages, ...dataUrls].slice(0, MAX_IMAGES_PER_MESSAGE),
+							setSelectedMedia((prevItems) =>
+								[...prevItems, ...dataUrls].slice(0, MAX_IMAGES_PER_MESSAGE),
 							)
 
 							if (typeof vscode !== "undefined") {
@@ -777,7 +775,7 @@ const ChatTextArea = forwardRef<HTMLTextAreaElement, ChatTextAreaProps>(
 				setCursorPosition,
 				setIntendedCursorPosition,
 				shouldDisableImages,
-				setSelectedImages,
+				setSelectedMedia,
 				t,
 			],
 		)
@@ -1031,10 +1029,10 @@ const ChatTextArea = forwardRef<HTMLTextAreaElement, ChatTextAreaProps>(
 					</div>
 				</div>
 
-				{selectedImages.length > 0 && (
-					<Thumbnails
-						images={selectedImages}
-						setImages={setSelectedImages}
+				{selectedMedia.length > 0 && (
+					<MediaThumbnails
+						mediaItems={selectedMedia}
+						setMediaItems={setSelectedMedia}
 						style={{
 							left: "16px",
 							zIndex: 2,

--- a/webview-ui/src/components/chat/TaskHeader.tsx
+++ b/webview-ui/src/components/chat/TaskHeader.tsx
@@ -14,7 +14,7 @@ import { Button, StandardTooltip } from "@src/components/ui"
 import { useExtensionState } from "@src/context/ExtensionStateContext"
 import { useSelectedModel } from "@/components/ui/hooks/useSelectedModel"
 
-import Thumbnails from "../common/Thumbnails"
+import MediaThumbnails from "../common/MediaThumbnails"
 
 import { TaskActions } from "./TaskActions"
 import { ShareButton } from "./ShareButton"
@@ -142,7 +142,7 @@ const TaskHeader = ({
 								<Mention text={task.text} />
 							</div>
 						</div>
-						{task.images && task.images.length > 0 && <Thumbnails images={task.images} />}
+						{task.images && task.images.length > 0 && <MediaThumbnails mediaItems={task.images} />}
 
 						<div className="flex flex-col gap-1">
 							{isTaskExpanded && contextWindow > 0 && (

--- a/webview-ui/src/components/chat/__tests__/ChatTextArea.spec.tsx
+++ b/webview-ui/src/components/chat/__tests__/ChatTextArea.spec.tsx
@@ -54,12 +54,13 @@ describe("ChatTextArea", () => {
 		onSelectImages: vi.fn(),
 		shouldDisableImages: false,
 		placeholderText: "Type a message...",
-		selectedImages: [],
-		setSelectedImages: vi.fn(),
+		selectedMedia: [],
+		setSelectedMedia: vi.fn(),
 		onHeightChange: vi.fn(),
 		mode: defaultModeSlug,
 		setMode: vi.fn(),
 		modeShortcutText: "(⌘. for next mode)",
+		acceptedFileTypes: [],
 	}
 
 	beforeEach(() => {

--- a/webview-ui/src/components/common/MediaThumbnails.tsx
+++ b/webview-ui/src/components/common/MediaThumbnails.tsx
@@ -1,0 +1,124 @@
+import React, { useState, useRef, useLayoutEffect, memo } from "react"
+import { useWindowSize } from "react-use"
+import { vscode } from "@src/utils/vscode"
+
+interface MediaThumbnailsProps {
+	mediaItems: string[]
+	style?: React.CSSProperties
+	setMediaItems?: React.Dispatch<React.SetStateAction<string[]>>
+	onHeightChange?: (height: number) => void
+}
+
+const getMimeType = (dataUri: string): string => {
+	return dataUri.substring(dataUri.indexOf(":") + 1, dataUri.indexOf(";"))
+}
+
+const MediaThumbnails = ({ mediaItems, style, setMediaItems, onHeightChange }: MediaThumbnailsProps) => {
+	const [hoveredIndex, setHoveredIndex] = useState<number | null>(null)
+	const containerRef = useRef<HTMLDivElement>(null)
+	const { width } = useWindowSize()
+
+	useLayoutEffect(() => {
+		if (containerRef.current) {
+			let height = containerRef.current.clientHeight
+			if (!height) {
+				height = containerRef.current.getBoundingClientRect().height
+			}
+			onHeightChange?.(height)
+		}
+		setHoveredIndex(null)
+	}, [mediaItems, width, onHeightChange])
+
+	const handleDelete = (index: number) => {
+		setMediaItems?.((prevItems) => prevItems.filter((_, i) => i !== index))
+	}
+
+	const isDeletable = setMediaItems !== undefined
+
+	const handleMediaClick = (mediaItem: string) => {
+		vscode.postMessage({ type: "openImage", text: mediaItem }) // This can be generalized later if needed
+	}
+
+	return (
+		<div
+			ref={containerRef}
+			style={{
+				display: "flex",
+				flexWrap: "wrap",
+				gap: 5,
+				rowGap: 3,
+				...style,
+			}}>
+			{mediaItems.map((mediaItem, index) => {
+				const mimeType = getMimeType(mediaItem)
+				const isVideo = mimeType.startsWith("video/")
+
+				return (
+					<div
+						key={index}
+						style={{ position: "relative" }}
+						onMouseEnter={() => setHoveredIndex(index)}
+						onMouseLeave={() => setHoveredIndex(null)}>
+						{isVideo ? (
+							<video
+								src={mediaItem}
+								muted
+								loop
+								autoPlay
+								playsInline
+								style={{
+									width: 34,
+									height: 34,
+									objectFit: "cover",
+									borderRadius: 4,
+									cursor: "pointer",
+								}}
+								onClick={() => handleMediaClick(mediaItem)}
+							/>
+						) : (
+							<img
+								src={mediaItem}
+								alt={`Thumbnail ${index + 1}`}
+								style={{
+									width: 34,
+									height: 34,
+									objectFit: "cover",
+									borderRadius: 4,
+									cursor: "pointer",
+								}}
+								onClick={() => handleMediaClick(mediaItem)}
+							/>
+						)}
+						{isDeletable && hoveredIndex === index && (
+							<div
+								onClick={() => handleDelete(index)}
+								style={{
+									position: "absolute",
+									top: -4,
+									right: -4,
+									width: 13,
+									height: 13,
+									borderRadius: "50%",
+									backgroundColor: "var(--vscode-badge-background)",
+									display: "flex",
+									justifyContent: "center",
+									alignItems: "center",
+									cursor: "pointer",
+								}}>
+								<span
+									className="codicon codicon-close"
+									style={{
+										color: "var(--vscode-foreground)",
+										fontSize: 10,
+										fontWeight: "bold",
+									}}></span>
+							</div>
+						)}
+					</div>
+				)
+			})}
+		</div>
+	)
+}
+
+export default memo(MediaThumbnails)


### PR DESCRIPTION
- Renamed `Thumbnails` to `MediaThumbnails` to support multiple media types
- Added MIME type detection for data URIs
- Implemented conditional rendering: images use <img>, videos use <video>
- Enabled video file selection only for Gemini-capable models (e.g. gemini-2.5-pro)
- Refactored state from `selectedImages` to `selectedMedia`
- Updated ChatTextArea to support dynamic accepted file types
- Replaced old thumbnail component usage across UI (ChatRow, TaskHeader, etc.)
- Adjusted unit tests to support new props and avoid breaking changes